### PR TITLE
Added __END__ after the code and before the pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
 Changelog for VSO
 
+2015-04-??      v0.025
+  - Added __END__ symbol. RT#72915
+
 2012-02-22      v0.024
   - Changed 'use VSO asa => "Foo::Class"' to 'use VSO extends => "Foo::Class"'
   - Documented the compile-time version of multiple-inheritance also: 'use VSO => [qw( Foo Bar )]'

--- a/lib/VSO.pm
+++ b/lib/VSO.pm
@@ -655,6 +655,7 @@ subtype 'Any' =>
 
 1;# return true:
 
+__END__
 
 
 =pod


### PR DESCRIPTION
Hi,

This is a very simple PR which adds the `__END__` symbol after the code and before the pod.

Addresses RT#72915

Cheers,
Neil
